### PR TITLE
add SanfordStoutNFT contract to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@
 2. install dependencies with `npm install`
 3. cp `.env.example` to `.env` and fill the required keys
 4. run the script of choice with `node day1/script.js`
+
+## Week 2 day 2
+
+Rinkeby testnet is depricated and not available anymore. Please use same contract deployed on Sepolia testnet. Here is details of contract https://sepolia.etherscan.io/address/0x1927c4eB0806bc7ff4F145Bc252187af5b8ba32E
+
+Also contact is also available in day2/contact directory if you want to deploy it to some different network yourself

--- a/day2/abi/sanfordNFTAbi.js
+++ b/day2/abi/sanfordNFTAbi.js
@@ -185,7 +185,7 @@ const ABI = [
       { internalType: "address", name: "from", type: "address" },
       { internalType: "address", name: "to", type: "address" },
       { internalType: "uint256", name: "tokenId", type: "uint256" },
-      { internalType: "bytes", name: "_data", type: "bytes" },
+      { internalType: "bytes", name: "data", type: "bytes" },
     ],
     name: "safeTransferFrom",
     outputs: [],

--- a/day2/contract/SanfordStoutNFT.sol
+++ b/day2/contract/SanfordStoutNFT.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+
+contract SanforStoutNFT is ERC721, Ownable {
+    using Counters for Counters.Counter;
+    Counters.Counter public tokenIdCounter;
+
+    uint256 public TOTAL_SUPPLY = 100;
+    uint256 public MINT_PRICE = 0.01 ether;
+
+    constructor() ERC721("Sanford Stout NFT", "SSN") {}
+
+    function _baseURI() internal pure virtual override returns (string memory) {
+        return
+            "ipfs://bafybeicce4ku2pode3f5keremouq3t4nmhrqh3yg6ptzjbkntb357z4jry/";
+    }
+
+    function mint() external payable {
+        require(msg.value >= MINT_PRICE, "Insufficient ETH amount");
+        require(
+            tokenIdCounter.current() < TOTAL_SUPPLY,
+            "Reached total supply"
+        );
+        tokenIdCounter.increment();
+
+        uint256 tokenId = tokenIdCounter.current();
+        _mint(msg.sender, tokenId);
+    }
+
+    function ownerMint(address to) external onlyOwner {
+        require(
+            tokenIdCounter.current() < TOTAL_SUPPLY,
+            "Reached total supply"
+        );
+        tokenIdCounter.increment();
+
+        uint256 tokenId = tokenIdCounter.current();
+        _mint(to, tokenId);
+    }
+
+    function withdraw(address _to, uint _amount) external onlyOwner {
+        require(
+            address(this).balance >= _amount,
+            "No enough ETH in the contract"
+        );
+        (bool success, ) = _to.call{value: _amount}("");
+        require(success, "Failed to send Ether");
+    }
+}


### PR DESCRIPTION
Rinkeby testnet is deprecated and Web2 to Web3 curriculum using contract deployed on rinkeby for read & write demo.

This change added raw contract under contract folder and also added link to same contract deployed on Sepolia testnet to make easier to follow.